### PR TITLE
tighten up show output, use full path for cfg file

### DIFF
--- a/procman/procman.py
+++ b/procman/procman.py
@@ -53,10 +53,10 @@ def show_paths():
         mod = importlib.import_module(modname)
         print(mod.__doc__)
 
-        print("\nUser cfg file:")
+        print("User cfg file:")
         _, cfg = mod.load_config()
-        print(f'  {cfg}')
-        print("\nUser scripts:")
+        print(f'  {cfg.resolve()}')
+        print("User scripts:")
         for item in mod.get_userscripts():
             print(f'  {item}')
 
@@ -78,6 +78,10 @@ def main(argv=None):  # pragma: no cover
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
         description='Process manager for user scripts',
     )
+    parser.add_argument('--version', action="version", version=f"%(prog)s {VERSION}")
+    parser.add_argument('-D', '--demo', help='Run demo config', action='store_true')
+    parser.add_argument('-S', '--show', help='Display user config', action='store_true')
+    parser.add_argument('-t', '--test', help='Run sanity checks', action='store_true')
     parser.add_argument(
         "-v",
         "--verbose",
@@ -98,12 +102,6 @@ def main(argv=None):  # pragma: no cover
         default='0',
         dest="runfor",
         help="Runtime STOP timer in seconds - 0 means run until whenever",
-    )
-    parser.add_argument('-D', '--demo', help='Run demo config', action='store_true')
-    parser.add_argument('-t', '--test', help='Run sanity checks', action='store_true')
-    parser.add_argument('--version', action="version", version=f"%(prog)s {VERSION}")
-    parser.add_argument(
-        '-S', '--show', help='Display user data paths', action='store_true'
     )
 
     args = parser.parse_args()

--- a/procman/utils.py
+++ b/procman/utils.py
@@ -34,7 +34,9 @@ def load_config(file_encoding='utf-8', file_extension='.yaml'):
 
     :param file_encoding: file encoding of config file
     :type file_encoding: str
-    :return tuple: Munch cfg obj
+    :param file_extension: file extension with leading separator
+    :type file_extension: str
+    :return tuple: Munch cfg obj, Path obj
     :raises FileTypeError: if the input file is not yml
     """
     proc_cfg = os.getenv('PROCMAN_CFG', default='')


### PR DESCRIPTION
* the demo config is a string and not a file, thus, if there is no local project config, then:
  * the `--show` command will display a "fictitious" user file
  * and the `--test` command will warn about it