### PR TITLE
use resolved paths for config and scripts

### DIFF
--- a/procman/utils.py
+++ b/procman/utils.py
@@ -51,7 +51,7 @@ def load_config(file_encoding='utf-8', file_extension='.yaml'):
         cfgobj = Munch.fromYAML(cfgfile.read_text(encoding=file_encoding))
     logging.debug('Using config: %s', str(cfgfile.resolve()))
 
-    return cfgobj, cfgfile
+    return cfgobj, cfgfile.resolve()
 
 
 def get_userscripts(demo_mode=False, file_encoding='utf-8', file_extension='.yaml'):

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -45,6 +45,13 @@ def test_load_config_bogus(monkeypatch):
 
 def test_get_userscripts():
     uscripts = get_userscripts(True)
+    # print(uscripts)
 
     assert isinstance(uscripts, list)
     assert len(uscripts) == 2
+
+    for item in uscripts:
+        path_str = item[1].split()[1]
+        print(path_str)
+        assert isinstance(path_str, str)
+        assert Path(path_str).is_absolute

--- a/tox.ini
+++ b/tox.ini
@@ -140,7 +140,7 @@ deps =
     .[examples]
 
 commands =
-    procman --countdown {posargs:10 --demo}
+    -procman --countdown {posargs:10 --demo}
 
 [testenv:changes]
 skip_install = true
@@ -167,7 +167,7 @@ deps =
     pip>=21.1
 
 commands =
-    bash -c 'make -C docs/ clean'
+    -bash -c 'make -C docs/ clean'
     bash -c 'rm -rf *.egg-info dump.* procman/__pycache__ dist/ build/ docs/source/api/ .procman.yaml'
 
 [testenv:docs]


### PR DESCRIPTION
* return resolved path obj from load_config, use it in get_userscripts
* update tests for full script path in get_userscripts list
